### PR TITLE
ci(android): wrap sdkmanager pipeline in retry

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -37,10 +37,10 @@ jobs:
           set -euo pipefail
           retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && { echo "FAILED: $*"; exit 1; }; echo "Retry $n/3..."; sleep 10; done; }
           yes | sdkmanager --update || true
-          retry yes | sdkmanager "cmdline-tools;latest"
-          retry yes | sdkmanager "platform-tools"
-          retry yes | sdkmanager "platforms;android-34"
-          retry yes | sdkmanager "build-tools;34.0.0"
+          retry bash -c "yes | sdkmanager 'cmdline-tools;latest'"
+          retry bash -c "yes | sdkmanager 'platform-tools'"
+          retry bash -c "yes | sdkmanager 'platforms;android-34'"
+          retry bash -c "yes | sdkmanager 'build-tools;34.0.0'"
           yes | sdkmanager --licenses
           echo "== SDK ROOT =="; echo "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
           echo "== SDK LIST (head) =="; sdkmanager --list | sed -n '1,200p' || true


### PR DESCRIPTION
## Summary
- fix Android workflow to retry sdkmanager command instead of only `yes`

## Testing
- `actionlint .github/workflows/android-ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c0a728ac0c832aa51fd0b36c1dd3f0